### PR TITLE
Add CNCF AWS Kubernetes project infra in an organization-unit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.terraform*
+

--- a/infra/kubernetes/README.org
+++ b/infra/kubernetes/README.org
@@ -1,0 +1,13 @@
+#+TITLE: CNCF infra for the Kubernetes project on AWS
+
+* Maintaining
+** Initialising
+#+begin_src shell
+terraform import aws_organizations_organization.Root ID_HERE
+#+end_src
+
+** Migrating tfstate
+Uncomment the lines relating to backend under ~terraform~ and run the following commands
+#+begin_src shell
+terraform init
+#+end_src

--- a/infra/kubernetes/main.tf
+++ b/infra/kubernetes/main.tf
@@ -65,7 +65,7 @@ resource "aws_organizations_organization" "Root" {
   }
 }
 
-// creating the org //
+// creating the org-unit //
 resource "aws_organizations_organizational_unit" "kubernetes" {
   name      = "kubernetes"
   parent_id = aws_organizations_organization.Root.id

--- a/infra/kubernetes/main.tf
+++ b/infra/kubernetes/main.tf
@@ -1,0 +1,88 @@
+// terraform config //
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+  # backend "s3" {
+  #   bucket  = "cncf-credits-infra-kubernetes-tfstate"
+  #   key     = "terraform.tfstate"
+  #   region  = "ap-southeast-2"
+  #   encrypt = true
+  # }
+}
+
+provider "aws" {
+  profile = "default"
+  region  = "ap-southeast-2"
+}
+// ---------------- //
+
+// the tfstate for the management of the kubernetes account+OU //
+resource "aws_kms_key" "cncf-credits-infra-kubernetes-tfstate" {
+  description = "This key is used to encrypt bucket objects"
+}
+resource "aws_s3_bucket" "cncf-credits-infra-kubernetes-tfstate" {
+  bucket = "cncf-credits-infra-kubernetes-tfstate"
+  acl    = "private"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  versioning {
+    enabled = true
+  }
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = aws_kms_key.cncf-credits-infra-kubernetes-tfstate.arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+}
+resource "aws_s3_bucket_ownership_controls" "cncf-credits-infra-kubernetes-tfstate" {
+  bucket = aws_s3_bucket.cncf-credits-infra-kubernetes-tfstate.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+resource "aws_s3_bucket_public_access_block" "cncf-credits-infra-kubernetes-tfstate" {
+  bucket = aws_s3_bucket.cncf-credits-infra-kubernetes-tfstate.id
+
+  block_public_acls   = true
+  block_public_policy = true
+}
+// ----------------------------------------------------------- //
+
+resource "aws_organizations_organization" "Root" {
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+// creating the org //
+resource "aws_organizations_organizational_unit" "kubernetes" {
+  name      = "kubernetes"
+  parent_id = aws_organizations_organization.Root.id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_organizations_account" "kubernetes" {
+  name                       = "kubernetes"
+  email                      = "k8s-infra-aws-root-account@kubernetes.io"
+  iam_user_access_to_billing = "ALLOW"
+  parent_id                  = aws_organizations_organizational_unit.kubernetes.id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+// ---------------- //

--- a/infra/kubernetes/main.tf
+++ b/infra/kubernetes/main.tf
@@ -23,6 +23,10 @@ provider "aws" {
 // the tfstate for the management of the kubernetes account+OU //
 resource "aws_kms_key" "cncf-credits-infra-kubernetes-tfstate" {
   description = "This key is used to encrypt bucket objects"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 resource "aws_s3_bucket" "cncf-credits-infra-kubernetes-tfstate" {
   bucket = "cncf-credits-infra-kubernetes-tfstate"
@@ -47,12 +51,20 @@ resource "aws_s3_bucket" "cncf-credits-infra-kubernetes-tfstate" {
 resource "aws_s3_bucket_ownership_controls" "cncf-credits-infra-kubernetes-tfstate" {
   bucket = aws_s3_bucket.cncf-credits-infra-kubernetes-tfstate.id
 
+  lifecycle {
+    prevent_destroy = true
+  }
+
   rule {
     object_ownership = "BucketOwnerEnforced"
   }
 }
 resource "aws_s3_bucket_public_access_block" "cncf-credits-infra-kubernetes-tfstate" {
   bucket = aws_s3_bucket.cncf-credits-infra-kubernetes-tfstate.id
+
+  lifecycle {
+    prevent_destroy = true
+  }
 
   block_public_acls   = true
   block_public_policy = true

--- a/infra/kubernetes/main.tf
+++ b/infra/kubernetes/main.tf
@@ -48,7 +48,7 @@ resource "aws_s3_bucket_ownership_controls" "cncf-credits-infra-kubernetes-tfsta
   bucket = aws_s3_bucket.cncf-credits-infra-kubernetes-tfstate.id
 
   rule {
-    object_ownership = "BucketOwnerPreferred"
+    object_ownership = "BucketOwnerEnforced"
   }
 }
 resource "aws_s3_bucket_public_access_block" "cncf-credits-infra-kubernetes-tfstate" {

--- a/infra/kubernetes/outputs.tf
+++ b/infra/kubernetes/outputs.tf
@@ -1,3 +1,3 @@
-output "kubernetes_account" {
+output "aws_organizations_account-kubernetes" {
   value = aws_organizations_account.kubernetes
 }

--- a/infra/kubernetes/outputs.tf
+++ b/infra/kubernetes/outputs.tf
@@ -1,0 +1,3 @@
+output "kubernetes_account" {
+  value = aws_organizations_account.kubernetes
+}


### PR DESCRIPTION
**PLEASE REVIEW, DO NOT MERGE**

This PR seeks to add a AWS org and account under the CNCF account via Terraform.

# What will be provisioned?
- a private and encrypted s3 storage bucket for Terraform state storage
- an organizational-unit
- an account, inside the organizational-unit

# Alternatives
- #3 :: difference being that an organizational-unit is provisioned instead of an organization in this PR

# Structure
```
cncf (org)
|
- kubernetes (org-unit)
  |
  - kubernetes account (k8s-infra-aws-root-account@kubernetes.io)
...
```