### PR TITLE
Add missing changepassword role

### DIFF
--- a/infra/aws/terraform/accounts/spire/main.tf
+++ b/infra/aws/terraform/accounts/spire/main.tf
@@ -89,6 +89,7 @@ resource "aws_iam_policy" "policy" {
         Action = [
           "iam:AddRoleToInstanceProfile",
           "iam:AddUserToGroup",
+          "iam:ChangePassword",
           "iam:CreateAccessKey",
           "iam:CreateGroup",
           "iam:CreateInstanceProfile",


### PR DESCRIPTION
When provided temp passwords with a change requirement, IAM users were unable to change passwords.

Related: https://github.com/cncf/credits/issues/6